### PR TITLE
Style resets

### DIFF
--- a/lib/css/editor.css
+++ b/lib/css/editor.css
@@ -12,10 +12,6 @@
   border: 1px solid #CCC;
   background-color: #EFEFEF;
 }
-#editorheader,
-#editorinnerheader {
-  background: white;
-}
 .editorheaderscroll {
   position: fixed;
   top: 0;

--- a/lib/css/stylesheet.css
+++ b/lib/css/stylesheet.css
@@ -176,6 +176,14 @@ body {
   font-family: serif;
   line-height: 1.3em;
 }
+body,
+#editorheader,
+#editorinnerheader {
+  background-color: #F3F3F3;
+}
+.bibleeditor {
+  background: #FFF;
+}
 h1,
 h2,
 h3,
@@ -296,9 +304,6 @@ textarea {
 }
 .clearfix {
   clear: both;
-}
-#topbar:hover {
-  background-color: #F9F9F9;
 }
 #topbar a {
   color: #000;

--- a/lib/css/stylesheet.css
+++ b/lib/css/stylesheet.css
@@ -299,6 +299,8 @@ textarea {
   font-family: Cardo;
   /* font-size: normal; : dynamically generated */
 }
+#oneeditor,
+span[contenteditable=true],
 .focusedverse {
   background: lightyellow;
 }

--- a/lib/css/stylesheet.css
+++ b/lib/css/stylesheet.css
@@ -182,6 +182,7 @@ h3,
 h4,
 h5,
 h6 {
+  margin: 0.5em 0;
   font-weight: bold;
   font-family: sans-serif;
 }

--- a/lib/css/stylesheet.css
+++ b/lib/css/stylesheet.css
@@ -181,10 +181,22 @@ h2,
 h3,
 h4,
 h5,
+h6,
+#name1,
+#name2,
+#name3,
+#topbar,
+#editorinnerheader {
+  font-family: sans-serif;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
 h6 {
   margin: 0.5em 0;
   font-weight: bold;
-  font-family: sans-serif;
 }
 h1 {
   font-size: 2em;

--- a/lib/css/stylesheet.css
+++ b/lib/css/stylesheet.css
@@ -1,8 +1,159 @@
-html {
+/* BEGIN CSS RESETS */
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
   margin: 0;
   padding: 0;
-  height: 100%;
+  border: 0;
+  background: transparent;
+  vertical-align: baseline;
+  font: inherit;
   font-size: 100%;
+}
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
+}
+ol,
+ul {
+  list-style: none;
+}
+blockquote,
+q {
+  quotes: none;
+}
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
+}
+table {
+  border-spacing: 0;
+  border-collapse: collapse;
+}
+hr {
+  display: block;
+  margin: 1em 0;
+  padding: 0;
+  height: 1px;
+  border: 0;
+  border-top: 1px solid #CCC;
+}
+input,
+select {
+  vertical-align: middle;
+}
+ins {
+  background-color: #FF9;
+  color: #000;
+  text-decoration: none;
+}
+mark {
+  background-color: #FF9;
+  color: #000;
+  font-weight: bold;
+  font-style: italic;
+}
+del {
+  text-decoration: line-through;
+}
+abbr[title],
+dfn[title] {
+  border-bottom: 1px dotted;
+  cursor: help;
+}
+/* END CSS RESETS */
+html {
+  height: 100%;
 }
 *,
 *:before,
@@ -22,16 +173,7 @@ body {
   margin: 0;
   padding: 0;
   height: 100%;
-}
-label {
-  font-size: 1em;
-}
-input {
-  font-size: 1em;
-}
-p {
-  margin: 0;
-  padding: 0;
+  line-height: 1;
 }
 strong {
   color: #488B9B;

--- a/lib/css/stylesheet.css
+++ b/lib/css/stylesheet.css
@@ -498,6 +498,9 @@ span[contenteditable=true],
   background-size: contain;
   background-repeat: no-repeat;
 }
+span[contenteditable=true] {
+  padding-right: 0.5em;
+}
 #workspacewrapper > table.editor {
   width: 100%;
 }

--- a/lib/css/stylesheet.css
+++ b/lib/css/stylesheet.css
@@ -174,7 +174,7 @@ body {
   padding: 0;
   height: 100%;
   font-family: serif;
-  line-height: 1;
+  line-height: 1.3em;
 }
 h1,
 h2,

--- a/lib/css/stylesheet.css
+++ b/lib/css/stylesheet.css
@@ -173,7 +173,35 @@ body {
   margin: 0;
   padding: 0;
   height: 100%;
+  font-family: serif;
   line-height: 1;
+}
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: bold;
+  font-family: sans-serif;
+}
+h1 {
+  font-size: 2em;
+}
+h2 {
+  font-size: 1.5em;
+}
+h3 {
+  font-size: 1.3em;
+}
+h4 {
+  font-size: 1.1em;
+}
+h5 {
+  font-size: 0.9em;
+}
+h6 {
+  font-size: 0.7em;
 }
 strong {
   color: #488B9B;

--- a/lib/unittests/tests/basic.css
+++ b/lib/unittests/tests/basic.css
@@ -3,1049 +3,542 @@
   font-size: x-small;
 }
 .add {
-  background-color: #FFF;
   font-style: italic;
 }
-.b {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .bd {
-  background-color: #FFF;
   font-weight: bold;
 }
 .bdit {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .bk {
-  background-color: #FFF;
   font-style: italic;
 }
 .c {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: -3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 250%;
 }
 .cd {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 92%;
 }
 .cls {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .d {
   margin-top: 4mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .dc {
-  background-color: #FFF;
   font-style: italic;
 }
 .em {
-  background-color: #FFF;
   font-style: italic;
 }
-.f {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
-.fdc {
-  background-color: #FFF;
-}
-.fe {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .fk {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .fl {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .fm {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
-.fp {
-  background-color: #FFF;
-}
 .fq {
-  background-color: #FFF;
   font-style: italic;
 }
 .fqa {
-  background-color: #FFF;
   font-style: italic;
 }
 .fr {
-  background-color: #FFF;
   font-weight: bold;
 }
-.ft {
-  background-color: #FFF;
-}
-.fv {
-  background-color: #FFF;
-}
 .ib {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 42%;
 }
 .iex {
   margin-top: 4mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
-}
-.im {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .imi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .imq {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .imt {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .imt1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .imt2 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 108%;
   page-break-inside: avoid;
 }
 .imt3 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .imt4 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .imte {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .io {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io4 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 31.8mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
-}
-.ior {
-  background-color: #FFF;
 }
 .iot {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .ip {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 5mm;
-  font-size: 100%;
 }
 .ipi {
-  margin-top: 0mm;
   margin-right: 6.3mm;
-  margin-bottom: 0mm;
   margin-left: 6.3mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .ipq {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-style: italic;
-  font-size: 100%;
 }
 .ipr {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
   text-align: right;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-style: italic;
-  font-size: 100%;
 }
 .is {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .is1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .is2 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .it {
-  background-color: #FFF;
   font-style: italic;
 }
 .k {
-  background-color: #FFF;
   font-style: italic;
 }
 .k1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .k2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .li {
-  margin-top: 0mm;
   margin-right: -9.3mm;
-  margin-bottom: 0mm;
   margin-left: 15.9mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .li1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li4 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 31.8mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .lit {
-  background-color: #FFF;
   font-weight: bold;
 }
-.m {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .mi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .mr {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .ms {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .ms1 {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .ms2 {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .mt {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mt1 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mt2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .mt3 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .mt4 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .mte {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mte1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mte2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .nb {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: justify;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .nd {
-  background-color: #FFF;
   text-decoration: underline;
 }
-.no {
-  background-color: #FFF;
-}
 .ord {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
 .p {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: justify;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .p1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .p2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 3.2mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .pc {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi1 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi2 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi3 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pm {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pmc {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pmo {
-  margin-top: 0mm;
   margin-right: 3.2mm;
-  margin-bottom: 0mm;
   margin-left: 3.2mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pmr {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pn {
-  background-color: #FFF;
   text-decoration: underline;
   font-weight: bold;
 }
 .q {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .q1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 24.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .q2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
-  font-size: 100%;
 }
 .q3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .qa {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .qac {
-  background-color: #FFF;
   font-style: italic;
 }
 .qc {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .qm {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .qm1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .qm2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
-  font-size: 100%;
 }
 .qm3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .qr {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .qs {
-  background-color: #FFF;
   font-style: italic;
 }
 .qt {
-  background-color: #FFF;
   font-style: italic;
 }
 .r {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .rq {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .s {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s2 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s3 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s4 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .sc {
-  background-color: #FFF;
   font-variant: small-caps;
 }
 .sig {
-  background-color: #FFF;
   font-style: italic;
 }
 .sls {
-  background-color: #FFF;
   font-style: italic;
 }
 .sp {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .sr {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .tl {
-  background-color: #FFF;
   font-style: italic;
 }
 .v {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
-.va {
-  background-color: #FFF;
-}
-.vp {
-  background-color: #FFF;
-}
 .wj {
-  background-color: #FFF;
   color: #F00;
 }
-.x {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
-.xdc {
-  background-color: #FFF;
-}
 .xk {
-  background-color: #FFF;
   font-style: italic;
 }
 .xo {
-  background-color: #FFF;
   font-weight: bold;
 }
 .xq {
-  background-color: #FFF;
   font-style: italic;
-}
-.xt {
-  background-color: #FFF;
 }

--- a/lib/unittests/tests/css.css
+++ b/lib/unittests/tests/css.css
@@ -6,12 +6,6 @@
   font-style: italic;
 }
 .b {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .bd {
@@ -25,40 +19,23 @@
   font-style: italic;
 }
 .c {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: -3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 30pt;
 }
 .cd {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 11pt;
 }
 .cls {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .d {
   margin-top: 4mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
   page-break-inside: avoid;
@@ -70,22 +47,10 @@
   font-style: italic;
 }
 .f {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
 }
 .fe {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
 }
@@ -111,285 +76,175 @@
   font-weight: bold;
 }
 .ib {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 5pt;
 }
 .iex {
   margin-top: 4mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
 }
 .im {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .imi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .imq {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
 }
 .imt {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 14pt;
   page-break-inside: avoid;
 }
 .imt1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 14pt;
   page-break-inside: avoid;
 }
 .imt2 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 13pt;
   page-break-inside: avoid;
 }
 .imt3 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .imt4 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .imte {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 20pt;
   page-break-inside: avoid;
 }
 .io {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .io1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .io2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .io3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .io4 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 31.8mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .iot {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .ip {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 5mm;
   font-size: 12pt;
 }
 .ipi {
-  margin-top: 0mm;
   margin-right: 6.3mm;
-  margin-bottom: 0mm;
   margin-left: 6.3mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
 }
 .ipq {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-style: italic;
   font-size: 12pt;
 }
 .ipr {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
   text-align: right;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
 }
 .iq {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-style: italic;
   font-size: 12pt;
 }
 .iq1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-style: italic;
   font-size: 12pt;
 }
 .iq2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
   font-style: italic;
   font-size: 12pt;
 }
 .iq3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-style: italic;
   font-size: 12pt;
 }
 .is {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .is1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .is2 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 12pt;
   page-break-inside: avoid;
@@ -401,67 +256,35 @@
   font-style: italic;
 }
 .k1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .k2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .li {
-  margin-top: 0mm;
   margin-right: -9.3mm;
-  margin-bottom: 0mm;
   margin-left: 15.9mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .li1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-size: 12pt;
 }
 .li2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-size: 12pt;
 }
 .li3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-size: 12pt;
 }
 .li4 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 31.8mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-size: 12pt;
 }
@@ -469,161 +292,107 @@
   font-weight: bold;
 }
 .m {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .mi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .mr {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .ms {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 14pt;
   page-break-inside: avoid;
 }
 .ms1 {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 14pt;
   page-break-inside: avoid;
 }
 .ms2 {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 14pt;
   page-break-inside: avoid;
 }
 .mt {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 20pt;
   page-break-inside: avoid;
 }
 .mt1 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 20pt;
   page-break-inside: avoid;
 }
 .mt2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 16pt;
   page-break-inside: avoid;
 }
 .mt3 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 16pt;
   page-break-inside: avoid;
 }
 .mt4 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .mte {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 20pt;
   page-break-inside: avoid;
 }
 .mte1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 20pt;
   page-break-inside: avoid;
 }
 .mte2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 16pt;
   page-break-inside: avoid;
 }
 .nb {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: justify;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .nd {
@@ -634,113 +403,69 @@
   font-size: x-small;
 }
 .p {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: justify;
   text-indent: 3.2mm;
   font-size: 12pt;
 }
 .p1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .p2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 3.2mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .pc {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .pi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
 }
 .pi1 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
 }
 .pi2 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
 }
 .pi3 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
 }
 .pm {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-size: 12pt;
 }
 .pmc {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .pmo {
-  margin-top: 0mm;
   margin-right: 3.2mm;
-  margin-bottom: 0mm;
   margin-left: 3.2mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .pmr {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
   text-align: right;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .pn {
@@ -748,48 +473,26 @@
   font-weight: bold;
 }
 .q {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-size: 12pt;
 }
 .q1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 24.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-size: 12pt;
 }
 .q2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
   font-size: 12pt;
 }
 .q3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-size: 12pt;
 }
 .qa {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
 }
@@ -797,57 +500,31 @@
   font-style: italic;
 }
 .qc {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .qm {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-size: 12pt;
 }
 .qm1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-size: 12pt;
 }
 .qm2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
   font-size: 12pt;
 }
 .qm3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-size: 12pt;
 }
 .qr {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
   font-size: 12pt;
 }
 .qs {
@@ -857,77 +534,52 @@
   font-style: italic;
 }
 .r {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .rq {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
 }
 .s {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .s1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .s2 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .s3 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .s4 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
   page-break-inside: avoid;
@@ -943,22 +595,14 @@
 }
 .sp {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
   page-break-inside: avoid;
 }
 .sr {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 12pt;
   page-break-inside: avoid;
@@ -974,12 +618,6 @@
   color: #F00;
 }
 .x {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 12pt;
 }

--- a/lib/unittests/tests/editor.css
+++ b/lib/unittests/tests/editor.css
@@ -356,7 +356,7 @@
   text-align: justify;
 }
 .nd {
-  text-decoration: underline;
+  font-variant: small-caps;
 }
 .ord {
   vertical-align: super;

--- a/lib/unittests/tests/editor.css
+++ b/lib/unittests/tests/editor.css
@@ -16,10 +16,22 @@
   font-style: italic;
 }
 .c {
-  margin-bottom: -3mm;
+  display: block;
+  float: left;
+  margin-top: 0.3em;
+  padding: 0 0.1em 0 0;
+  vertical-align: text-top;
   font-weight: bold;
-  font-size: 250%;
+  font-size: 2.2em;
 }
+.c + p {
+  text-indent: 0;
+}
+/* (Optinal way to hide verse marker at start of chapter)
+.c + p > .v {
+  display: none;
+}
+*/
 .cd {
   margin-top: 8mm;
   margin-bottom: 4mm;

--- a/lib/unittests/tests/editor.css
+++ b/lib/unittests/tests/editor.css
@@ -3,1049 +3,542 @@
   font-size: x-small;
 }
 .add {
-  background-color: #FFF;
   font-style: italic;
 }
-.b {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .bd {
-  background-color: #FFF;
   font-weight: bold;
 }
 .bdit {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .bk {
-  background-color: #FFF;
   font-style: italic;
 }
 .c {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: -3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 250%;
 }
 .cd {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 92%;
 }
 .cls {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .d {
   margin-top: 4mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .dc {
-  background-color: #FFF;
   font-style: italic;
 }
 .em {
-  background-color: #FFF;
   font-style: italic;
 }
-.f {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
-.fdc {
-  background-color: #FFF;
-}
-.fe {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .fk {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .fl {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .fm {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
-.fp {
-  background-color: #FFF;
-}
 .fq {
-  background-color: #FFF;
   font-style: italic;
 }
 .fqa {
-  background-color: #FFF;
   font-style: italic;
 }
 .fr {
-  background-color: #FFF;
   font-weight: bold;
 }
-.ft {
-  background-color: #FFF;
-}
-.fv {
-  background-color: #FFF;
-}
 .ib {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 42%;
 }
 .iex {
   margin-top: 4mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
-}
-.im {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .imi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .imq {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .imt {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .imt1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .imt2 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 108%;
   page-break-inside: avoid;
 }
 .imt3 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .imt4 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .imte {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .io {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io4 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 31.8mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
-}
-.ior {
-  background-color: #FFF;
 }
 .iot {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .ip {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 5mm;
-  font-size: 100%;
 }
 .ipi {
-  margin-top: 0mm;
   margin-right: 6.3mm;
-  margin-bottom: 0mm;
   margin-left: 6.3mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .ipq {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-style: italic;
-  font-size: 100%;
 }
 .ipr {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
   text-align: right;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-style: italic;
-  font-size: 100%;
 }
 .is {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .is1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .is2 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .it {
-  background-color: #FFF;
   font-style: italic;
 }
 .k {
-  background-color: #FFF;
   font-style: italic;
 }
 .k1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .k2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .li {
-  margin-top: 0mm;
   margin-right: -9.3mm;
-  margin-bottom: 0mm;
   margin-left: 15.9mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .li1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li4 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 31.8mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .lit {
-  background-color: #FFF;
   font-weight: bold;
 }
-.m {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .mi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .mr {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .ms {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .ms1 {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .ms2 {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .mt {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mt1 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mt2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .mt3 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .mt4 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .mte {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mte1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mte2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .nb {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: justify;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .nd {
-  background-color: #FFF;
   text-decoration: underline;
 }
-.no {
-  background-color: #FFF;
-}
 .ord {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
 .p {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: justify;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .p1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .p2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 3.2mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .pc {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi1 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi2 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi3 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pm {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pmc {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pmo {
-  margin-top: 0mm;
   margin-right: 3.2mm;
-  margin-bottom: 0mm;
   margin-left: 3.2mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pmr {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pn {
-  background-color: #FFF;
   text-decoration: underline;
   font-weight: bold;
 }
 .q {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .q1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 24.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .q2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
-  font-size: 100%;
 }
 .q3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .qa {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .qac {
-  background-color: #FFF;
   font-style: italic;
 }
 .qc {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .qm {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .qm1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .qm2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
-  font-size: 100%;
 }
 .qm3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .qr {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .qs {
-  background-color: #FFF;
   font-style: italic;
 }
 .qt {
-  background-color: #FFF;
   font-style: italic;
 }
 .r {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .rq {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .s {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s2 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s3 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s4 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .sc {
-  background-color: #FFF;
   font-variant: small-caps;
 }
 .sig {
-  background-color: #FFF;
   font-style: italic;
 }
 .sls {
-  background-color: #FFF;
   font-style: italic;
 }
 .sp {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .sr {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .tl {
-  background-color: #FFF;
   font-style: italic;
 }
 .v {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
-.va {
-  background-color: #FFF;
-}
-.vp {
-  background-color: #FFF;
-}
 .wj {
-  background-color: #FFF;
   color: #F00;
 }
-.x {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
-.xdc {
-  background-color: #FFF;
-}
 .xk {
-  background-color: #FFF;
   font-style: italic;
 }
 .xo {
-  background-color: #FFF;
   font-weight: bold;
 }
 .xq {
-  background-color: #FFF;
   font-style: italic;
-}
-.xt {
-  background-color: #FFF;
 }

--- a/lib/unittests/tests/exports.css
+++ b/lib/unittests/tests/exports.css
@@ -36,1049 +36,542 @@ a:hover {
   font-size: normal;
 }
 .add {
-  background-color: #FFF;
   font-style: italic;
 }
-.b {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .bd {
-  background-color: #FFF;
   font-weight: bold;
 }
 .bdit {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .bk {
-  background-color: #FFF;
   font-style: italic;
 }
 .c {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: -3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 250%;
 }
 .cd {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 92%;
 }
 .cls {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .d {
   margin-top: 4mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .dc {
-  background-color: #FFF;
   font-style: italic;
 }
 .em {
-  background-color: #FFF;
   font-style: italic;
 }
-.f {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
-.fdc {
-  background-color: #FFF;
-}
-.fe {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .fk {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .fl {
-  background-color: #FFF;
   font-weight: bold;
   font-style: italic;
 }
 .fm {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
-.fp {
-  background-color: #FFF;
-}
 .fq {
-  background-color: #FFF;
   font-style: italic;
 }
 .fqa {
-  background-color: #FFF;
   font-style: italic;
 }
 .fr {
-  background-color: #FFF;
   font-weight: bold;
 }
-.ft {
-  background-color: #FFF;
-}
-.fv {
-  background-color: #FFF;
-}
 .ib {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-size: 42%;
 }
 .iex {
   margin-top: 4mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
-}
-.im {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .imi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .imq {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .imt {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .imt1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .imt2 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 108%;
   page-break-inside: avoid;
 }
 .imt3 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .imt4 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .imte {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .io {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .io4 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 31.8mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
-}
-.ior {
-  background-color: #FFF;
 }
 .iot {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .ip {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 5mm;
-  font-size: 100%;
 }
 .ipi {
-  margin-top: 0mm;
   margin-right: 6.3mm;
-  margin-bottom: 0mm;
   margin-left: 6.3mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .ipq {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
   font-style: italic;
-  font-size: 100%;
 }
 .ipr {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
   text-align: right;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
   font-style: italic;
-  font-size: 100%;
 }
 .iq3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
   font-style: italic;
-  font-size: 100%;
 }
 .is {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .is1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .is2 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .it {
-  background-color: #FFF;
   font-style: italic;
 }
 .k {
-  background-color: #FFF;
   font-style: italic;
 }
 .k1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .k2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .li {
-  margin-top: 0mm;
   margin-right: -9.3mm;
-  margin-bottom: 0mm;
   margin-left: 15.9mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .li1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .li4 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 31.8mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .lit {
-  background-color: #FFF;
   font-weight: bold;
 }
-.m {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
 .mi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .mr {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .ms {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .ms1 {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .ms2 {
   margin-top: 16mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 117%;
   page-break-inside: avoid;
 }
 .mt {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mt1 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mt2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .mt3 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .mt4 {
   margin-top: 2mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .mte {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mte1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
   font-size: 167%;
   page-break-inside: avoid;
 }
 .mte2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 2mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
   font-size: 133%;
   page-break-inside: avoid;
 }
 .nb {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: justify;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .nd {
-  background-color: #FFF;
   text-decoration: underline;
 }
-.no {
-  background-color: #FFF;
-}
 .ord {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
 .p {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: justify;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .p1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .p2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 3.2mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .pc {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pi {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi1 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi2 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 12.7mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pi3 {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 19.1mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pm {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
   text-indent: 3.2mm;
-  font-size: 100%;
 }
 .pmc {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pmo {
-  margin-top: 0mm;
   margin-right: 3.2mm;
-  margin-bottom: 0mm;
   margin-left: 3.2mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pmr {
-  margin-top: 0mm;
   margin-right: 6.4mm;
-  margin-bottom: 0mm;
   margin-left: 6.4mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .pn {
-  background-color: #FFF;
   text-decoration: underline;
   font-weight: bold;
 }
 .q {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .q1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 24.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .q2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
-  font-size: 100%;
 }
 .q3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .qa {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .qac {
-  background-color: #FFF;
   font-style: italic;
 }
 .qc {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .qm {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .qm1 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -19.1mm;
-  font-size: 100%;
 }
 .qm2 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -12.7mm;
-  font-size: 100%;
 }
 .qm3 {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
   margin-left: 25.4mm;
-  text-align: left;
   text-indent: -6.4mm;
-  font-size: 100%;
 }
 .qr {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
-  font-size: 100%;
 }
 .qs {
-  background-color: #FFF;
   font-style: italic;
 }
 .qt {
-  background-color: #FFF;
   font-style: italic;
 }
 .r {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .rq {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: right;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
 }
 .s {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s1 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s2 {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s3 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .s4 {
   margin-top: 6mm;
-  margin-right: 0mm;
   margin-bottom: 3mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .sc {
-  background-color: #FFF;
   font-variant: small-caps;
 }
 .sig {
-  background-color: #FFF;
   font-style: italic;
 }
 .sls {
-  background-color: #FFF;
   font-style: italic;
 }
 .sp {
   margin-top: 8mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
   font-style: italic;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .sr {
-  margin-top: 0mm;
-  margin-right: 0mm;
   margin-bottom: 4mm;
-  margin-left: 0mm;
   text-align: center;
-  text-indent: 0mm;
   font-weight: bold;
-  font-size: 100%;
   page-break-inside: avoid;
 }
 .tl {
-  background-color: #FFF;
   font-style: italic;
 }
 .v {
-  background-color: #FFF;
   vertical-align: super;
   font-size: x-small;
 }
-.va {
-  background-color: #FFF;
-}
-.vp {
-  background-color: #FFF;
-}
 .wj {
-  background-color: #FFF;
   color: #F00;
 }
-.x {
-  margin-top: 0mm;
-  margin-right: 0mm;
-  margin-bottom: 0mm;
-  margin-left: 0mm;
-  text-align: left;
-  text-indent: 0mm;
-  font-size: 100%;
-}
-.xdc {
-  background-color: #FFF;
-}
 .xk {
-  background-color: #FFF;
   font-style: italic;
 }
 .xo {
-  background-color: #FFF;
   font-weight: bold;
 }
 .xq {
-  background-color: #FFF;
   font-style: italic;
-}
-.xt {
-  background-color: #FFF;
 }


### PR DESCRIPTION
Let me preface this with two comments:
- I am not a graphic designer. I'm sure there are ways to make the interface look more visually appealing than these rules accomplish. The major purpose here was not to accomplish a facelift so much as to cleanup the _code_ so that it was easier to work on and design ideas could be implemented easier.
- Any of these pieces can be applied piecemeal, if something in this set doesn't appeal to you let know and I'll bump that bit and rebase the branch so this merge can be clean.

As I started to work of a redesign for the menus, I discovered the overall CSS was pretty difficult to work with. The combination of element nesting and style cascading was so convoluted that adjusting values was pretty difficult. Sometimes a value was getting set at one level, tweaked at another, then reset again at a more specific level. Other places rules were just straight up conflicting or redundant. These changes don't eliminate all of these ambiguities, but they go a long way.

As mentioned in #135 there is an issue where style sheets from the unittests/tests directory are ending up in the production interface. This doesn't fix that, but it does cleanup the bloat of no-op styles so that when those are moved to the right place they will be closer to cleaned up.

One of the major things I was angling here was starting to separate the BE user interface elements from the application content. I personally found the totally monolithic combination of UI and content to be very confusing getting started and (although they can't articulate this) I think it's one of the underlying reasons my team has found it "so confusing".

The split is far from complete because the markup being generated for the most part makes no distinctions, but there are a few styles here to at least _start_ the process of separating UI from content.
- Use sans fonts for UI elements.
- Use serif fonts for Bible and resource content.
- A highlight existed for the current focused verse in an editor, but add another kind of highlight such that all of the canvas areas where the user can expect to be able to edit when focused are highlighted vs. the rest of the interface that has fixed content. This is currently subtle enough it's likely to suffer the same fate as the verse highlighter in #133 where some LCDs and light conditions don't even register it, but as the markup generated by the app is cleaned up it should get easier and easier to make a deliberate distinction and a better visual design could be chosen.
