### PR TITLE
(More) scroll fixes

### DIFF
--- a/lib/edit/index.js
+++ b/lib/edit/index.js
@@ -592,13 +592,12 @@ function editorScrollVerseIntoView ()
       verses = usfm_get_verse_numbers (element[0].textContent);
       if (verses.indexOf (parseInt (editorNavigationVerse)) >= 0) {
         if (navigated == false) {
-          var offset = element.offset ();
-          var verseTop = offset.top;
-          var viewportHeight = $(window).height ();
-          var scrollTo = verseTop - (viewportHeight * verticalCaretPosition / 100);
-          var currentScrollTop = $ (document).scrollTop ();
-          var lowerBoundary = currentScrollTop - (viewportHeight / 10);
-          var upperBoundary = currentScrollTop + (viewportHeight / 10);
+          var verseTop = element.offset().top;
+          var workspaceHeight = $("#workspacewrapper").height();
+          var scrollTo = verseTop - (workspaceHeight * verticalCaretPosition / 100);
+          var currentScrollTop = $("#workspacewrapper").scrollTop ();
+          var lowerBoundary = currentScrollTop - (workspaceHeight / 10);
+          var upperBoundary = currentScrollTop + (workspaceHeight / 10);
           if ((scrollTo < lowerBoundary) || (scrollTo > upperBoundary)) {
             $ ("#workspacewrapper").animate ({ scrollTop: scrollTo }, 500);
           }

--- a/lib/edit/index.js
+++ b/lib/edit/index.js
@@ -594,12 +594,12 @@ function editorScrollVerseIntoView ()
         if (navigated == false) {
           var verseTop = element.offset().top;
           var workspaceHeight = $("#workspacewrapper").height();
-          var scrollTo = verseTop - (workspaceHeight * verticalCaretPosition / 100);
-          var currentScrollTop = $("#workspacewrapper").scrollTop ();
+          var currentScrollTop = $("#workspacewrapper").scrollTop();
+          var scrollTo = verseTop - (workspaceHeight * verticalCaretPosition / 100) + currentScrollTop;
           var lowerBoundary = currentScrollTop - (workspaceHeight / 10);
           var upperBoundary = currentScrollTop + (workspaceHeight / 10);
           if ((scrollTo < lowerBoundary) || (scrollTo > upperBoundary)) {
-            $ ("#workspacewrapper").animate ({ scrollTop: scrollTo }, 500);
+            $("#workspacewrapper").animate({ scrollTop: scrollTo }, 500);
           }
           navigated = true;
         }

--- a/lib/editone/index.js
+++ b/lib/editone/index.js
@@ -347,12 +347,16 @@ Section for scrolling the editable portion into the center.
 
 function oneverseScrollVerseIntoView ()
 {
-  $ ("body").stop ();
-  var element = $ ("#oneeditor");
-  var verseTop = element.offset().top;
-  var workspaceHeight = $("#workspacewrapper").height ();
-  var scrollTo = verseTop - (workspaceHeight * verticalCaretPosition / 100);
-  $ ("#workspacewrapper").animate ({ scrollTop: scrollTo }, 500);
+  $("#workspacewrapper").stop();
+  var verseTop = $("#oneeditor").offset().top;
+  var workspaceHeight = $("#workspacewrapper").height();
+  var currentScrollTop = $("#workspacewrapper").scrollTop();
+  var scrollTo = verseTop - (workspaceHeight * verticalCaretPosition / 100) + currentScrollTop;
+  var lowerBoundary = currentScrollTop - (workspaceHeight / 10);
+  var upperBoundary = currentScrollTop + (workspaceHeight / 10);
+  if ((scrollTo < lowerBoundary) || (scrollTo > upperBoundary)) {
+    $("#workspacewrapper").animate({ scrollTop: scrollTo }, 500);
+  }
 }
 
 

--- a/lib/editone/index.js
+++ b/lib/editone/index.js
@@ -349,10 +349,9 @@ function oneverseScrollVerseIntoView ()
 {
   $ ("body").stop ();
   var element = $ ("#oneeditor");
-  var offset = element.offset ();
-  var verseTop = offset.top;
-  var viewportHeight = $(window).height ();
-  var scrollTo = verseTop - (viewportHeight * verticalCaretPosition / 100);
+  var verseTop = element.offset().top;
+  var workspaceHeight = $("#workspacewrapper").height ();
+  var scrollTo = verseTop - (workspaceHeight * verticalCaretPosition / 100);
   $ ("#workspacewrapper").animate ({ scrollTop: scrollTo }, 500);
 }
 

--- a/lib/editone/index.js
+++ b/lib/editone/index.js
@@ -198,7 +198,7 @@ function oneverseEditorSaveVerse (sync)
     async: oneverseSaveAsync,
     data: { bible: oneverseBible, book: oneverseBook, chapter: oneverseChapter, verse: oneverseVerseLoaded, html: encodedHtml, checksum: checksum, style: oneverseAddedStyle },
     error: function (jqXHR, textStatus, errorThrown) {
-      oneverseEditorStatus (oneverseEditorChapterRetrying);
+      oneverseEditorStatus (oneverseEditorVerseRetrying);
       oneverseLoadedText = "";
       oneverseEditorChanged ();
       if (!oneverseSaveAsync) oneverseEditorSaveVerse (true);


### PR DESCRIPTION
Do you realize the browser is being told to scroll the page once a second (on every poll event) no matter whether content changes or not? This doesn't fix that but it does fix the issue commented on in #141 as well as some other scenarios. It also reduces the scroll requests from twice per data poll request to once and uses the same logic for whether a scroll should happen or not (within x% of edge) for both the single verse and chapter editors. Really these shouldn't be separate sets of code anyway, but normalizing them in a bigger project that I can mess with today, so this is a band-aid.
